### PR TITLE
Availability and Strategy Update

### DIFF
--- a/apps/server/src/index.js
+++ b/apps/server/src/index.js
@@ -18,10 +18,13 @@ app.use(cookieParser());
 // --------------- Routes ---------------
 const authRoutes = require("./routes/auth");
 const workspaceRoutes = require("./routes/workspaces");
+const notificationRoutes = require("./routes/notifications");
+const responseRoutes = require("./routes/responses");
 
 app.use("/api/auth", authRoutes);
 app.use("/api/workspaces", workspaceRoutes);
-
+app.use("/api/notifications", notificationRoutes);
+app.use("/api/response", responseRoutes);
 
 app.get("/api/health", (_req, res) => {
   const dbStates = ["disconnected", "connected", "connecting", "disconnecting"];
@@ -30,38 +33,6 @@ app.get("/api/health", (_req, res) => {
     timestamp: new Date().toISOString(),
     db: dbStates[mongoose.connection.readyState] || "unknown",
   });
-});
-
-const Response = require("./models/Response");
-const { requireAuth } = require("./middleware/auth");
-
-app.post("/api/response", async (req, res) => {
-  try {
-    console.log("Incoming data:", req.body);
-
-    const newResponse = new Response(req.body);
-    await newResponse.save();
-
-    res.json({ message: "Saved successfully!" });
-  } catch (err) {
-    console.error("Error saving:", err);
-    res.status(500).json({ error: "Failed to save" });
-  }
-});
-
-// GET responses for a workspace (used by instructor page)
-app.get("/api/response", async (req, res) => {
-  try {
-    const { workspaceId } = req.query;
-    if (!workspaceId) {
-      return res.status(400).json({ error: "workspaceId is required" });
-    }
-    const responses = await Response.find({ workspaceId });
-    res.json({ responses });
-  } catch (err) {
-    console.error("Error fetching responses:", err);
-    res.status(500).json({ error: "Failed to fetch responses" });
-  }
 });
 
 // --------------- Start ---------------

--- a/apps/server/src/routes/notifications.js
+++ b/apps/server/src/routes/notifications.js
@@ -1,0 +1,53 @@
+const express = require("express");
+const router = express.Router();
+const mongoose = require("mongoose");
+const Notification = require("../models/Notification");
+const { requireAuth } = require("../middleware/auth");
+
+// GET /api/notifications — fetch all notifications for the current user
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const notifications = await Notification.find({
+      userId: new mongoose.Types.ObjectId(req.user.id),
+    }).sort({ createdAt: -1 });
+
+    return res.json({ notifications });
+  } catch (err) {
+    console.error("Error fetching notifications:", err);
+    return res.status(500).json({ error: "Failed to fetch notifications" });
+  }
+});
+
+// PATCH /api/notifications/:id/read — mark one notification as read
+router.patch("/:id/read", requireAuth, async (req, res) => {
+  try {
+    const notification = await Notification.findOneAndUpdate(
+      { _id: req.params.id, userId: new mongoose.Types.ObjectId(req.user.id) },
+      { read: true },
+      { new: true }
+    );
+
+    if (!notification) {
+      return res.status(404).json({ error: "Notification not found" });
+    }
+
+    return res.json({ notification });
+  } catch (err) {
+    return res.status(500).json({ error: "Failed to update notification" });
+  }
+});
+
+// PATCH /api/notifications/read-all — mark all as read for current user
+router.patch("/read-all", requireAuth, async (req, res) => {
+  try {
+    await Notification.updateMany(
+      { userId: new mongoose.Types.ObjectId(req.user.id), read: false },
+      { read: true }
+    );
+    return res.json({ message: "All notifications marked as read" });
+  } catch (err) {
+    return res.status(500).json({ error: "Failed to update notifications" });
+  }
+});
+
+module.exports = router;

--- a/apps/server/src/routes/responses.js
+++ b/apps/server/src/routes/responses.js
@@ -1,0 +1,208 @@
+const express = require("express");
+const router = express.Router();
+const mongoose = require("mongoose");
+const Response = require("../models/Response");
+const Workspace = require("../models/Workspace");
+const Notification = require("../models/Notification");
+const { requireAuth } = require("../middleware/auth");
+
+// helpers
+
+/**
+ * Convert an array of availability entries from the survey into a
+ * structured availabilityGrid map:
+ *   { "Monday": ["09:00-10:00", "14:00-15:00"], "Tuesday": [...] }
+ *
+ * Each entry can be:
+ *   { day, startTime, endTime }  (object from the survey UI)
+ *   "Monday 09:00-10:00"         (legacy string)
+ */
+function buildAvailabilityGrid(availabilityAnswer) {
+  if (!Array.isArray(availabilityAnswer)) return {};
+
+  const grid = {};
+
+  for (const entry of availabilityAnswer) {
+    if (typeof entry === "string") {
+      // "Monday 09:00-10:00"
+      const parts = entry.split(" ");
+      if (parts.length >= 2) {
+        const day = parts[0];
+        const slot = parts.slice(1).join(" ");
+        if (!grid[day]) grid[day] = [];
+        if (!grid[day].includes(slot)) grid[day].push(slot);
+      }
+    } else if (entry && entry.day && entry.startTime && entry.endTime) {
+      const { day, startTime, endTime } = entry;
+      const slot = `${startTime}-${endTime}`;
+      if (!grid[day]) grid[day] = [];
+      if (!grid[day].includes(slot)) grid[day].push(slot);
+    }
+  }
+
+  return grid;
+}
+
+/**
+ * Detect scheduling conflicts: two responses in the same workspace that
+ * share NO common availability slot.
+ * Returns array of { participantA, participantB } objects.
+ */
+function detectConflicts(responses) {
+  const conflicts = [];
+
+  for (let i = 0; i < responses.length; i++) {
+    for (let j = i + 1; j < responses.length; j++) {
+      const a = responses[i];
+      const b = responses[j];
+
+      const gridA = a.availabilityGrid || {};
+      const gridB = b.availabilityGrid || {};
+
+      let hasOverlap = false;
+
+      outer: for (const day of Object.keys(gridA)) {
+        if (gridB[day]) {
+          for (const slot of gridA[day]) {
+            if (gridB[day].includes(slot)) {
+              hasOverlap = true;
+              break outer;
+            }
+          }
+        }
+      }
+
+      if (!hasOverlap) {
+        conflicts.push({
+          participantA: a.participantId,
+          participantB: b.participantId,
+        });
+      }
+    }
+  }
+
+  return conflicts;
+}
+
+// POST /api/response
+// Save a survey response, populate availabilityGrid, run conflict detection,
+// and create notifications for the workspace organizer + affected participants.
+
+router.post("/", requireAuth, async (req, res) => {
+  try {
+    const { workspaceId, answers, whitelistEmails, blacklistEmails } = req.body;
+
+    if (!workspaceId) {
+      return res.status(400).json({ error: "workspaceId is required" });
+    }
+
+    // Find the availability answer from the submitted answers array
+    const availAnswer = Array.isArray(answers)
+      ? answers.find((a) => a.questionId === "availability")
+      : null;
+
+    const availabilityGrid = buildAvailabilityGrid(availAnswer?.value);
+
+    // Upsert: one response per participant per workspace
+    const responseDoc = await Response.findOneAndUpdate(
+      {
+        workspaceId: new mongoose.Types.ObjectId(workspaceId),
+        participantId: new mongoose.Types.ObjectId(req.user.id),
+      },
+      {
+        workspaceId,
+        participantId: req.user.id,
+        answers: Array.isArray(answers) ? answers : [],
+        availabilityGrid,
+        whitelistEmails: whitelistEmails || [],
+        blacklistEmails: blacklistEmails || [],
+      },
+      { upsert: true, new: true }
+    );
+
+    // Conflict detection
+    const allResponses = await Response.find({
+      workspaceId: new mongoose.Types.ObjectId(workspaceId),
+    });
+
+    const conflicts = detectConflicts(allResponses);
+
+    // Notify the workspace organiser about any new conflicts
+    const workspace = await Workspace.findById(workspaceId);
+    if (workspace && conflicts.length > 0) {
+      await Notification.create({
+        userId: workspace.organizerId,
+        message: `⚠️ ${conflicts.length} scheduling conflict(s) detected in workspace "${workspace.name}". Check the Availability Grid.`,
+      });
+
+      // Notify each conflicting participant pair
+      for (const { participantA, participantB } of conflicts) {
+        await Notification.create({
+          userId: participantA,
+          message: `⚠️ Your availability in "${workspace.name}" conflicts with another participant. Update your survey to enable better team matching.`,
+        });
+        await Notification.create({
+          userId: participantB,
+          message: `⚠️ Your availability in "${workspace.name}" conflicts with another participant. Update your survey to enable better team matching.`,
+        });
+      }
+    }
+
+    return res.json({
+      message: "Saved successfully!",
+      response: responseDoc,
+      conflictsDetected: conflicts.length,
+    });
+  } catch (err) {
+    console.error("Error saving response:", err);
+    return res.status(500).json({ error: "Failed to save response" });
+  }
+});
+
+// GET /api/response?workspaceId=...
+// Fetch all survey responses for a workspace (used by instructor + availability grid).
+
+router.get("/", requireAuth, async (req, res) => {
+  try {
+    const { workspaceId } = req.query;
+    if (!workspaceId) {
+      return res.status(400).json({ error: "workspaceId is required" });
+    }
+
+    const responses = await Response.find({
+      workspaceId: new mongoose.Types.ObjectId(workspaceId),
+    }).populate("participantId", "name email avatar");
+
+    // Include conflict summary
+    const conflicts = detectConflicts(responses);
+
+    return res.json({ responses, conflictsDetected: conflicts.length, conflicts });
+  } catch (err) {
+    console.error("Error fetching responses:", err);
+    return res.status(500).json({ error: "Failed to fetch responses" });
+  }
+});
+
+// GET /api/response/my?workspaceId=...
+// Fetch the authenticated participant's own response for a workspace.
+
+router.get("/my", requireAuth, async (req, res) => {
+  try {
+    const { workspaceId } = req.query;
+    if (!workspaceId) {
+      return res.status(400).json({ error: "workspaceId is required" });
+    }
+
+    const response = await Response.findOne({
+      workspaceId: new mongoose.Types.ObjectId(workspaceId),
+      participantId: new mongoose.Types.ObjectId(req.user.id),
+    });
+
+    return res.json({ response: response || null });
+  } catch (err) {
+    console.error("Error fetching own response:", err);
+    return res.status(500).json({ error: "Failed to fetch response" });
+  }
+});
+
+module.exports = router;

--- a/apps/web/src/app/instructor/availability/page.js
+++ b/apps/web/src/app/instructor/availability/page.js
@@ -1,261 +1,448 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, AlertTriangle, CheckCircle2, RefreshCw } from "lucide-react";
 
 import Navbar from "@/components/Navbar";
 import {
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
 } from "@/components/ui/table";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5001";
 
+const DAYS_ORDER = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+function sortSlots(slots) {
+  return [...slots].sort((a, b) => {
+    const [dayA, timeA = ""] = a.split(" ");
+    const [dayB, timeB = ""] = b.split(" ");
+    const dA = DAYS_ORDER.indexOf(dayA);
+    const dB = DAYS_ORDER.indexOf(dayB);
+    if (dA !== dB) return dA - dB;
+    return timeA.localeCompare(timeB);
+  });
+}
+
 export default function AvailabilityPage() {
-    const { data: session } = useSession();
+  const { data: session } = useSession();
 
-    const [students, setStudents] = useState([]);
-    const [workspaces, setWorkspaces] = useState([]);
-    const [activeWorkspaceId, setActiveWorkspaceId] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState("");
+  const [students, setStudents] = useState([]);
+  const [workspaces, setWorkspaces] = useState([]);
+  const [activeWorkspaceId, setActiveWorkspaceId] = useState(null);
+  const [conflicts, setConflicts] = useState([]);
+  const [conflictsDetected, setConflictsDetected] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
 
-    const localStorageKey = useMemo(() => {
-        const email = session?.user?.email || "guest";
-        return `gmatch_workspaces_${email}`;
-    }, [session]);
-    
-    useEffect(() => {
-        loadWorkspaces();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        }, [session]);
+  const localStorageKey = useMemo(() => {
+    const email = session?.user?.email || "guest";
+    return `gmatch_workspaces_${email}`;
+  }, [session]);
 
-    useEffect(() => {
-        if (workspaces.length > 0) {
-        const urlParams = new URLSearchParams(window.location.search);
-        const urlWsId = urlParams.get("workspaceId");
+  const loadWorkspaces = useCallback(async () => {
+    setError("");
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/workspaces`, {
+        credentials: "include",
+        headers: { Authorization: `Bearer ${session?.token || ""}` },
+      });
+      if (!response.ok) throw new Error("Backend unavailable");
 
-        if (urlWsId && workspaces.some((w) => w._id === urlWsId)) {
-            setActiveWorkspaceId(urlWsId);
-        } else if (!activeWorkspaceId) {
-            setActiveWorkspaceId(workspaces[0]._id);
-        }
-        }
-    }, [workspaces, activeWorkspaceId]);
+      const data = await response.json();
+      const fetched = data.workspaces || [];
+      setWorkspaces(fetched);
 
-    useEffect(() => {
-        if (!activeWorkspaceId) {
+      if (fetched.length > 0 && !activeWorkspaceId) {
+        // Prefer workspaceId from URL
+        const urlWsId = new URLSearchParams(window.location.search).get("workspaceId");
+        const match = urlWsId && fetched.some((w) => w._id === urlWsId);
+        setActiveWorkspaceId(match ? urlWsId : fetched[0]._id);
+      }
+    } catch {
+      const saved = localStorage.getItem(localStorageKey);
+      const parsed = saved ? JSON.parse(saved) : [];
+      setWorkspaces(parsed);
+      if (parsed.length > 0 && !activeWorkspaceId) {
+        setActiveWorkspaceId(parsed[0]._id);
+      } else {
         setLoading(false);
-        return;
-        }
-
-        fetchResponses();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [activeWorkspaceId, session]);
-
-    const loadWorkspaces = async () => {
-        setError("");
-
-        try {
-        const response = await fetch(`${API_BASE_URL}/api/workspaces`, {
-            credentials: "include",
-            headers: {
-            Authorization: `Bearer ${session?.token || ""}`,
-            },
-        });
-
-        if (!response.ok) {
-            throw new Error("Backend unavailable");
-        }
-
-        const data = await response.json();
-        const fetchedWorkspaces = data.workspaces || [];
-        setWorkspaces(fetchedWorkspaces);
-
-        if (fetchedWorkspaces.length > 0 && !activeWorkspaceId) {
-            setActiveWorkspaceId(fetchedWorkspaces[0]._id);
-        } else if (fetchedWorkspaces.length === 0) {
-            setLoading(false);
-        }
-        } catch (_err) {
-        const saved = localStorage.getItem(localStorageKey);
-        const parsed = saved ? JSON.parse(saved) : [];
-
-        setWorkspaces(parsed);
-
-        if (parsed.length > 0 && !activeWorkspaceId) {
-            setActiveWorkspaceId(parsed[0]._id);
-        } else {
-            setLoading(false);
-        }
-        }
-    };
-
-    const fetchResponses = async () => {
-        setLoading(true);
-        setError("");
-
-        try {
-        const res = await fetch(
-            `${API_BASE_URL}/api/response?workspaceId=${activeWorkspaceId}`,
-            {
-            headers: {
-                Authorization: `Bearer ${session?.token || ""}`,
-            },
-            credentials: "include",
-            }
-        );
-
-        if (!res.ok) {
-            throw new Error("Could not load survey responses.");
-        }
-
-        const data = await res.json();
-
-        const mapped = (data.responses || []).map((r) => {
-            const nameAnswer = r.answers?.find((a) => a.questionId === "name");
-            const availAnswer = r.answers?.find(
-            (a) => a.questionId === "availability"
-            );
-
-            const availability = Array.isArray(availAnswer?.value)
-            ? availAnswer.value
-                .map((v) => {
-                    if (typeof v === "string") return v;
-
-                    if (v?.day && v?.startTime && v?.endTime) {
-                    return `${v.day} ${v.startTime}-${v.endTime}`;
-                    }
-
-                    if (v?.day) return v.day;
-
-                    return null;
-                })
-                .filter(Boolean)
-            : [];
-
-            return {
-            name: nameAnswer?.value || "Unknown",
-            availability,
-            };
-        });
-
-        setStudents(mapped);
-        } catch (err) {
-        console.error("Failed to fetch survey responses:", err);
-        setError("Could not load availability data.");
-        } finally {
-        setLoading(false);
-        }
-    };
-
-    const allSlots = Array.from(
-        new Set(students.flatMap((student) => student.availability || []))
-    );
-
-    return (
-        <>
-        <Navbar />
-
-        <main className="min-h-screen bg-background p-6">
-            <div className="mx-auto max-w-7xl space-y-6">
-            <Link
-                href="/instructor"
-                className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-            >
-                <ArrowLeft className="h-4 w-4" />
-                Back to Instructor Dashboard
-            </Link>
-
-            <Card className="shadow-sm">
-                <CardHeader>
-                <CardTitle>Availability Grid</CardTitle>
-                <CardDescription>
-                    View student availability collected from survey responses.
-                </CardDescription>
-                </CardHeader>
-
-                <CardContent className="space-y-4">
-                {loading ? (
-                    <p className="text-sm text-muted-foreground">
-                    Loading availability...
-                    </p>
-                ) : error ? (
-                    <p className="text-sm text-red-500">{error}</p>
-                ) : students.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                    No survey responses yet.
-                    </p>
-                ) : allSlots.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">
-                    No availability data found in survey responses.
-                    </p>
-                ) : (
-                    <>
-                    <div className="flex flex-wrap gap-3">
-                        <Badge>Available</Badge>
-                        <Badge variant="secondary">Not Available</Badge>
-                    </div>
-
-                    <div className="overflow-x-auto rounded-md border">
-                        <Table>
-                        <TableHeader>
-                            <TableRow>
-                            <TableHead className="min-w-[180px]">Student</TableHead>
-                            {allSlots.map((slot) => (
-                                <TableHead key={slot} className="whitespace-nowrap">
-                                {slot}
-                                </TableHead>
-                            ))}
-                            </TableRow>
-                        </TableHeader>
-
-                        <TableBody>
-                            {students.map((student) => (
-                            <TableRow key={student.name}>
-                                <TableCell className="font-medium">
-                                {student.name}
-                                </TableCell>
-
-                                {allSlots.map((slot) => {
-                                const isAvailable =
-                                    student.availability.includes(slot);
-
-                                return (
-                                    <TableCell key={slot}>
-                                    {isAvailable ? (
-                                        <Badge>Available</Badge>
-                                    ) : (
-                                        <Badge variant="secondary">—</Badge>
-                                    )}
-                                    </TableCell>
-                                );
-                                })}
-                            </TableRow>
-                            ))}
-                        </TableBody>
-                        </Table>
-                    </div>
-                    </>
-                )}
-                </CardContent>
-            </Card>
-            </div>
-        </main>
-        </>
-    );
+      }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session, localStorageKey]);
+
+  const fetchResponses = useCallback(async () => {
+    if (!activeWorkspaceId) { setLoading(false); return; }
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch(
+        `${API_BASE_URL}/api/response?workspaceId=${activeWorkspaceId}`,
+        {
+          headers: { Authorization: `Bearer ${session?.token || ""}` },
+          credentials: "include",
+        }
+      );
+
+      if (!res.ok) throw new Error("Could not load survey responses.");
+
+      const data = await res.json();
+
+      // Map responses — use availabilityGrid (structured) if present,
+      // otherwise fall back to answers array for legacy data.
+      const mapped = (data.responses || []).map((r) => {
+        const nameAnswer = r.answers?.find((a) => a.questionId === "name");
+        const skillsAnswer = r.answers?.find((a) => a.questionId === "skills");
+
+        // Build slot list from availabilityGrid (new) or availability answer (legacy)
+        let slots = [];
+
+        if (r.availabilityGrid && Object.keys(r.availabilityGrid).length > 0) {
+          for (const [day, times] of Object.entries(r.availabilityGrid)) {
+            for (const time of times) {
+              slots.push(`${day} ${time}`);
+            }
+          }
+        } else {
+          // Legacy path: answers array
+          const availAnswer = r.answers?.find((a) => a.questionId === "availability");
+          if (Array.isArray(availAnswer?.value)) {
+            slots = availAnswer.value
+              .map((v) => {
+                if (typeof v === "string") return v;
+                if (v?.day && v?.startTime && v?.endTime)
+                  return `${v.day} ${v.startTime}-${v.endTime}`;
+                if (v?.day) return v.day;
+                return null;
+              })
+              .filter(Boolean);
+          }
+        }
+
+        return {
+          id: r._id,
+          name: nameAnswer?.value || r.participantId?.name || "Unknown",
+          skills: Array.isArray(skillsAnswer?.value) ? skillsAnswer.value : [],
+          slots,
+        };
+      });
+
+      setStudents(mapped);
+      setConflictsDetected(data.conflictsDetected || 0);
+      setConflicts(data.conflicts || []);
+    } catch (err) {
+      console.error("Failed to fetch survey responses:", err);
+      setError("Could not load availability data.");
+    } finally {
+      setLoading(false);
+    }
+  }, [activeWorkspaceId, session]);
+
+  useEffect(() => { loadWorkspaces(); }, [loadWorkspaces]);
+  useEffect(() => { if (activeWorkspaceId) fetchResponses(); }, [activeWorkspaceId, fetchResponses]);
+
+  const activeWorkspace = workspaces.find((w) => w._id === activeWorkspaceId);
+
+  // All unique day+time slots across all students, sorted
+  const allSlots = useMemo(
+    () => sortSlots(Array.from(new Set(students.flatMap((s) => s.slots)))),
+    [students]
+  );
+
+  // Group slots by day for column grouping display
+  const slotsByDay = useMemo(() => {
+    const map = {};
+    for (const slot of allSlots) {
+      const day = slot.split(" ")[0];
+      if (!map[day]) map[day] = [];
+      map[day].push(slot);
+    }
+    return map;
+  }, [allSlots]);
+
+  // Coverage: how many students cover each slot
+  const slotCoverage = useMemo(() => {
+    const coverage = {};
+    for (const slot of allSlots) {
+      coverage[slot] = students.filter((s) => s.slots.includes(slot)).length;
+    }
+    return coverage;
+  }, [allSlots, students]);
+
+  return (
+    <>
+      <Navbar />
+      <main className="min-h-screen bg-background p-6">
+        <div className="mx-auto max-w-full space-y-6">
+          <Link
+            href={activeWorkspaceId ? `/instructor?workspaceId=${activeWorkspaceId}` : "/instructor"}
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Instructor Dashboard
+          </Link>
+
+          {/* Workspace selector */}
+          {workspaces.length > 1 && (
+            <div className="flex flex-wrap gap-2">
+              {workspaces.map((ws) => (
+                <button
+                  key={ws._id}
+                  onClick={() => setActiveWorkspaceId(ws._id)}
+                  className={`rounded-full px-4 py-1.5 text-sm font-medium border transition-colors ${
+                    ws._id === activeWorkspaceId
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "bg-background text-muted-foreground border-border hover:border-primary hover:text-foreground"
+                  }`}
+                >
+                  {ws.name}
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Conflict alert */}
+          {!loading && conflictsDetected > 0 && (
+            <div className="flex items-start gap-3 rounded-lg border border-yellow-300 bg-yellow-50 p-4 dark:border-yellow-700 dark:bg-yellow-950">
+              <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-yellow-600 dark:text-yellow-400" />
+              <div>
+                <p className="font-medium text-yellow-800 dark:text-yellow-300">
+                  {conflictsDetected} scheduling conflict{conflictsDetected !== 1 ? "s" : ""} detected
+                </p>
+                <p className="mt-1 text-sm text-yellow-700 dark:text-yellow-400">
+                  Some participant pairs share no common availability slots. Consider reaching out or adjusting team assignments.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {!loading && conflictsDetected === 0 && students.length > 1 && (
+            <div className="flex items-center gap-3 rounded-lg border border-green-300 bg-green-50 p-4 dark:border-green-700 dark:bg-green-950">
+              <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600 dark:text-green-400" />
+              <p className="text-sm font-medium text-green-800 dark:text-green-300">
+                No conflicts detected — all participants share at least one common slot.
+              </p>
+            </div>
+          )}
+
+          {/* Main grid card */}
+          <Card className="shadow-sm">
+            <CardHeader className="flex flex-row items-start justify-between gap-4">
+              <div>
+                <CardTitle>
+                  Availability Grid
+                  {activeWorkspace && (
+                    <span className="ml-2 text-base font-normal text-muted-foreground">
+                      — {activeWorkspace.name}
+                    </span>
+                  )}
+                </CardTitle>
+                <CardDescription>
+                  Survey responses from {students.length} participant{students.length !== 1 ? "s" : ""}.
+                  Slots are colour-coded by coverage.
+                </CardDescription>
+              </div>
+              <Button variant="outline" size="sm" onClick={fetchResponses} className="gap-1.5 shrink-0">
+                <RefreshCw className="h-3.5 w-3.5" />
+                Refresh
+              </Button>
+            </CardHeader>
+
+            <CardContent className="space-y-4">
+              {loading ? (
+                <p className="text-sm text-muted-foreground">Loading availability…</p>
+              ) : error ? (
+                <p className="text-sm text-red-500">{error}</p>
+              ) : students.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No survey responses yet.</p>
+              ) : allSlots.length === 0 ? (
+                <p className="text-sm text-muted-foreground">No availability data found in survey responses.</p>
+              ) : (
+                <>
+                  {/* Legend */}
+                  <div className="flex flex-wrap items-center gap-4 text-xs">
+                    <span className="flex items-center gap-1.5">
+                      <span className="inline-block h-3 w-3 rounded-sm bg-emerald-500" />
+                      Available
+                    </span>
+                    <span className="flex items-center gap-1.5">
+                      <span className="inline-block h-3 w-3 rounded-sm bg-muted border" />
+                      Not available
+                    </span>
+                    <span className="flex items-center gap-1.5">
+                      <span className="inline-block h-3 w-3 rounded-sm bg-emerald-200" />
+                      Partial coverage
+                    </span>
+                  </div>
+
+                  <div className="overflow-x-auto rounded-md border">
+                    <Table>
+                      <TableHeader>
+                        {/* Day group header row */}
+                        <TableRow className="bg-muted/40">
+                          <TableHead className="min-w-[160px] border-r">Participant</TableHead>
+                          {Object.entries(slotsByDay).map(([day, daySlots]) => (
+                            <TableHead
+                              key={day}
+                              colSpan={daySlots.length}
+                              className="text-center border-r font-semibold"
+                            >
+                              {day}
+                            </TableHead>
+                          ))}
+                        </TableRow>
+                        {/* Time slot sub-header row */}
+                        <TableRow>
+                          <TableHead className="border-r" />
+                          {allSlots.map((slot, i) => {
+                            const timeOnly = slot.split(" ").slice(1).join(" ");
+                            const isLastInDay =
+                              i === allSlots.length - 1 ||
+                              allSlots[i + 1].split(" ")[0] !== slot.split(" ")[0];
+                            const coveragePct = students.length > 0
+                              ? slotCoverage[slot] / students.length
+                              : 0;
+
+                            return (
+                              <TableHead
+                                key={slot}
+                                className={`whitespace-nowrap text-center text-xs ${isLastInDay ? "border-r" : ""}`}
+                                title={`${slot} — ${slotCoverage[slot]}/${students.length} available`}
+                              >
+                                <div>{timeOnly || slot}</div>
+                                <div
+                                  className={`mt-1 text-[10px] font-normal ${
+                                    coveragePct >= 0.7
+                                      ? "text-emerald-700"
+                                      : coveragePct >= 0.3
+                                      ? "text-yellow-600"
+                                      : "text-muted-foreground"
+                                  }`}
+                                >
+                                  {slotCoverage[slot]}/{students.length}
+                                </div>
+                              </TableHead>
+                            );
+                          })}
+                        </TableRow>
+                      </TableHeader>
+
+                      <TableBody>
+                        {students.map((student) => (
+                          <TableRow key={student.id || student.name}>
+                            <TableCell className="font-medium border-r">
+                              <div>{student.name}</div>
+                              {student.skills.length > 0 && (
+                                <div className="mt-1 flex flex-wrap gap-1">
+                                  {student.skills.map((sk) => (
+                                    <span
+                                      key={sk}
+                                      className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary"
+                                    >
+                                      {sk}
+                                    </span>
+                                  ))}
+                                </div>
+                              )}
+                            </TableCell>
+
+                            {allSlots.map((slot, i) => {
+                              const isAvail = student.slots.includes(slot);
+                              const isLastInDay =
+                                i === allSlots.length - 1 ||
+                                allSlots[i + 1].split(" ")[0] !== slot.split(" ")[0];
+
+                              return (
+                                <TableCell
+                                  key={slot}
+                                  className={`text-center ${isLastInDay ? "border-r" : ""} ${
+                                    isAvail ? "bg-emerald-50 dark:bg-emerald-950" : ""
+                                  }`}
+                                >
+                                  {isAvail ? (
+                                    <span className="text-emerald-600 text-base">✓</span>
+                                  ) : (
+                                    <span className="text-muted-foreground/30 text-xs">—</span>
+                                  )}
+                                </TableCell>
+                              );
+                            })}
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+
+                  {/* Conflict detail table */}
+                  {conflicts.length > 0 && (
+                    <div className="mt-6">
+                      <h3 className="mb-2 text-sm font-semibold text-yellow-800 dark:text-yellow-300">
+                        Conflict Details
+                      </h3>
+                      <div className="rounded-md border border-yellow-200 dark:border-yellow-800 overflow-hidden">
+                        <Table>
+                          <TableHeader>
+                            <TableRow className="bg-yellow-50 dark:bg-yellow-950">
+                              <TableHead>#</TableHead>
+                              <TableHead>Participant A</TableHead>
+                              <TableHead>Participant B</TableHead>
+                              <TableHead>Issue</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
+                            {conflicts.map((c, i) => {
+                              const nameA =
+                                students.find(
+                                  (s) =>
+                                    s.id === String(c.participantA) ||
+                                    s.id === c.participantA?._id
+                                )?.name || String(c.participantA);
+                              const nameB =
+                                students.find(
+                                  (s) =>
+                                    s.id === String(c.participantB) ||
+                                    s.id === c.participantB?._id
+                                )?.name || String(c.participantB);
+
+                              return (
+                                <TableRow key={i}>
+                                  <TableCell className="text-muted-foreground">{i + 1}</TableCell>
+                                  <TableCell className="font-medium">{nameA}</TableCell>
+                                  <TableCell className="font-medium">{nameB}</TableCell>
+                                  <TableCell className="text-sm text-yellow-700 dark:text-yellow-400">
+                                    No overlapping availability
+                                  </TableCell>
+                                </TableRow>
+                              );
+                            })}
+                          </TableBody>
+                        </Table>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/app/instructor/instructor.css
+++ b/apps/web/src/app/instructor/instructor.css
@@ -1,3 +1,4 @@
+/* Base page layout */
 .instructor-page {
   min-height: 100vh;
   padding: 40px 20px;
@@ -15,6 +16,7 @@
   color: #111827;
 }
 
+/* Cards */
 .instructor-card {
   background: #ffffff;
   padding: 24px;
@@ -29,26 +31,16 @@
   color: #111827;
 }
 
+/* Form rows / fields */
 .instructor-row {
   display: flex;
   gap: 16px;
   flex-wrap: wrap;
 }
 
-.instructor-field-wide {
-  flex: 2;
-  min-width: 240px;
-}
-
-.instructor-field {
-  flex: 1;
-  min-width: 180px;
-}
-
-.instructor-team-field {
-  flex: 1;
-  min-width: 200px;
-}
+.instructor-field-wide { flex: 2; min-width: 240px; }
+.instructor-field      { flex: 1; min-width: 180px; }
+.instructor-team-field { flex: 1; min-width: 200px; }
 
 .instructor-label {
   display: block;
@@ -68,6 +60,7 @@
   background: #ffffff;
 }
 
+/* Buttons */
 .instructor-button {
   padding: 12px 18px;
   border: none;
@@ -76,17 +69,10 @@
   color: #ffffff;
   font-weight: 700;
   cursor: pointer;
-  transition: 0.2s ease;
+  transition: opacity 0.2s ease;
 }
-
-.instructor-button:hover {
-  opacity: 0.92;
-}
-
-.instructor-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
+.instructor-button:hover    { opacity: 0.92; }
+.instructor-button:disabled { cursor: not-allowed; opacity: 0.7; }
 
 .instructor-button-secondary {
   padding: 12px 18px;
@@ -120,6 +106,7 @@
   text-decoration: underline;
 }
 
+/* Status / text */
 .instructor-message {
   margin-top: 14px;
   margin-bottom: 0;
@@ -127,11 +114,18 @@
   font-weight: 700;
 }
 
-.instructor-muted {
+.instructor-muted  { color: #6b7280; margin: 0; }
+.instructor-text   { color: #374151; }
+
+.strategy-help {
+  margin-top: 10px;
+  margin-bottom: 0;
   color: #6b7280;
-  margin: 0;
+  font-size: 14px;
+  line-height: 1.5;
 }
 
+/* ── Workspace tabs ───────────────────────────────────────────── */
 .workspace-tabs {
   display: flex;
   flex-wrap: wrap;
@@ -147,10 +141,10 @@
   color: #374151;
   font-weight: 700;
   cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
 }
-
 .workspace-tab.active {
-  border: 1px solid #1d4ed8;
+  border-color: #1d4ed8;
   background: #dbeafe;
   color: #1d4ed8;
 }
@@ -161,25 +155,12 @@
   background: #f9fafb;
   border: 1px solid #e5e7eb;
 }
+.workspace-details p              { margin: 0 0 8px; color: #374151; }
+.workspace-details p:last-child   { margin-bottom: 0; }
 
-.workspace-details p {
-  margin: 0 0 8px 0;
-  color: #374151;
-}
-
-.workspace-details p:last-child {
-  margin-bottom: 0;
-}
-
-.question-list {
-  padding-left: 20px;
-  margin-bottom: 16px;
-}
-
-.question-list li {
-  margin-bottom: 10px;
-  color: #374151;
-}
+/* Survey questions */
+.question-list          { padding-left: 20px; margin-bottom: 16px; }
+.question-list li       { margin-bottom: 10px; color: #374151; }
 
 .remove-button {
   margin-left: 10px;
@@ -191,21 +172,11 @@
   cursor: pointer;
 }
 
-.inline-input-row {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-}
+.inline-input-row               { display: flex; gap: 10px; flex-wrap: wrap; }
+.inline-input-row .instructor-input { flex: 1; min-width: 250px; }
 
-.inline-input-row .instructor-input {
-  flex: 1;
-  min-width: 250px;
-}
-
-.actions-row {
-  margin-top: 30px;
-  margin-bottom: 20px;
-}
+/* Team generation */
+.actions-row { margin-top: 30px; margin-bottom: 20px; }
 
 .team-box {
   margin-bottom: 10px;
@@ -215,47 +186,181 @@
   border: 1px solid #bfdbfe;
 }
 
-.config-list {
-  padding-left: 20px;
-  margin: 0;
-  color: #4b5563;
+/* Config list */
+.config-list          { padding-left: 20px; margin: 0; color: #4b5563; }
+.config-list li       { margin-bottom: 6px; }
+
+/* Top action row (View Availability Grid button) */
+.top-actions-row {
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
 }
 
-.config-list li {
-  margin-bottom: 6px;
-}
-
-.instructor-text {
-  color: #374151;
-}
-
-.strategy-help {
-  margin-top: 10px;
-  margin-bottom: 0;
-  color: #6b7280;
+.availability-grid-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 8px;
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  color: #15803d;
+  font-weight: 700;
   font-size: 14px;
-  line-height: 1.5;
+  text-decoration: none !important;
+  transition: background 0.15s, border-color 0.15s;
+}
+.availability-grid-button:hover {
+  background: #dcfce7;
+  border-color: #4ade80;
 }
 
+/* ── Availability grid page ───────────────────────────────────── */
+
+/* Workspace selector pills on the availability page */
+.avail-workspace-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.avail-workspace-tab {
+  padding: 6px 16px;
+  border-radius: 999px;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  color: #374151;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+.avail-workspace-tab.active {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+/* Conflict / ok banners */
+.avail-conflict-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid #fde68a;
+  background: #fffbeb;
+  color: #92400e;
+}
+.avail-conflict-banner svg { flex-shrink: 0; margin-top: 2px; }
+.avail-conflict-banner strong { display: block; margin-bottom: 2px; }
+
+.avail-ok-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  border: 1px solid #bbf7d0;
+  background: #f0fdf4;
+  color: #166534;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+/* Grid table tweaks */
+.avail-table-wrap {
+  overflow-x: auto;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+}
+
+.avail-day-header {
+  background: #f9fafb;
+  font-weight: 700;
+  text-align: center;
+  border-right: 1px solid #e5e7eb;
+  font-size: 13px;
+}
+
+.avail-time-header {
+  text-align: center;
+  font-size: 11px;
+  white-space: nowrap;
+  padding: 6px 8px;
+}
+.avail-time-header.last-in-day { border-right: 1px solid #e5e7eb; }
+
+.avail-coverage-high   { color: #15803d; font-size: 10px; }
+.avail-coverage-mid    { color: #b45309; font-size: 10px; }
+.avail-coverage-low    { color: #9ca3af; font-size: 10px; }
+
+.avail-cell-yes  { background: #f0fdf4; text-align: center; }
+.avail-cell-no   { text-align: center; }
+.avail-cell-yes.last-in-day,
+.avail-cell-no.last-in-day  { border-right: 1px solid #e5e7eb; }
+
+.avail-check  { color: #16a34a; font-size: 16px; }
+.avail-dash   { color: #d1d5db; font-size: 12px; }
+
+/* Skill chips inside student name cell */
+.avail-skill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  margin-top: 4px;
+}
+.avail-skill-chip {
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+/* Conflict detail table */
+.avail-conflict-table-wrap {
+  margin-top: 20px;
+  border-radius: 8px;
+  border: 1px solid #fde68a;
+  overflow: hidden;
+}
+.avail-conflict-table-title {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #92400e;
+}
+.avail-conflict-row td { font-size: 13px; }
+
+/* Legend */
+.avail-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 12px;
+  color: #6b7280;
+  align-items: center;
+}
+.avail-legend-dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+/* Responsive */
 @media (max-width: 768px) {
-  .instructor-page {
-    padding: 24px 14px;
-  }
-
-  .instructor-title {
-    font-size: 26px;
-  }
-
-  .instructor-button-secondary {
-    margin-left: 0;
-    margin-top: 10px;
-  }
-
-  .top-actions-row {
-    margin-bottom: 20px;
-  }
-
-  .availability-grid-button {
-    text-decoration: none;
-  }
+  .instructor-page         { padding: 24px 14px; }
+  .instructor-title        { font-size: 26px; }
+  .instructor-button-secondary { margin-left: 0; margin-top: 10px; }
+  .top-actions-row         { margin-bottom: 20px; }
+  .availability-grid-button { text-decoration: none; }
 }

--- a/apps/web/src/app/instructor/page.js
+++ b/apps/web/src/app/instructor/page.js
@@ -91,13 +91,33 @@ export default function DashboardPage() {
           const mapped = (data.responses || []).map((r) => {
             const nameAnswer = r.answers?.find((a) => a.questionId === "name");
             const skillsAnswer = r.answers?.find((a) => a.questionId === "skills");
-            const availAnswer = r.answers?.find((a) => a.questionId === "availability");
-            // availability may be [{day,startTime,endTime}] — flatten to day strings
-            const availability = Array.isArray(availAnswer?.value)
-              ? availAnswer.value.map((v) => (typeof v === "string" ? v : v.day)).filter(Boolean)
-              : [];
+
+            // Prefer the structured availabilityGrid (populated by server on submit).
+            // Fall back to legacy answers array for older records.
+            let availability = [];
+            if (r.availabilityGrid && Object.keys(r.availabilityGrid).length > 0) {
+              for (const [day, times] of Object.entries(r.availabilityGrid)) {
+                for (const time of times) {
+                  availability.push(`${day} ${time}`);
+                }
+              }
+            } else {
+              const availAnswer = r.answers?.find((a) => a.questionId === "availability");
+              availability = Array.isArray(availAnswer?.value)
+                ? availAnswer.value
+                    .map((v) => {
+                      if (typeof v === "string") return v;
+                      if (v?.day && v?.startTime && v?.endTime)
+                        return `${v.day} ${v.startTime}-${v.endTime}`;
+                      if (v?.day) return v.day;
+                      return null;
+                    })
+                    .filter(Boolean)
+                : [];
+            }
+
             return {
-              name: nameAnswer?.value || "Unknown",
+              name: nameAnswer?.value || r.participantId?.name || "Unknown",
               skills: Array.isArray(skillsAnswer?.value) ? skillsAnswer.value : [],
               availability,
             };

--- a/apps/web/src/components/Navbar.jsx
+++ b/apps/web/src/components/Navbar.jsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
+import NotificationsBell from "@/components/NotificationsBell";
 
 export default function Navbar({ variant = "landing" }) {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -36,14 +37,17 @@ export default function Navbar({ variant = "landing" }) {
             </span>
           </Link>
 
-          {/* Always show hamburger */}
-          <button
-            type="button"
-            className="flex h-11 w-11 items-center justify-center rounded-xl border border-border bg-background text-muted-foreground transition hover:bg-muted"
-            onClick={() => setMenuOpen(true)}
-          >
-            <Menu className="h-6 w-6" />
-          </button>
+          {/* Right side: bell + hamburger */}
+          <div className="flex items-center gap-2">
+            <NotificationsBell />
+            <button
+              type="button"
+              className="flex h-11 w-11 items-center justify-center rounded-xl border border-border bg-background text-muted-foreground transition hover:bg-muted"
+              onClick={() => setMenuOpen(true)}
+            >
+              <Menu className="h-6 w-6" />
+            </button>
+          </div>
         </div>
       </nav>
 

--- a/apps/web/src/components/NotificationsBell.jsx
+++ b/apps/web/src/components/NotificationsBell.jsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { Bell } from "lucide-react";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5001";
+
+export default function NotificationsBell() {
+  const { data: session } = useSession();
+  const [notifications, setNotifications] = useState([]);
+  const [open, setOpen] = useState(false);
+
+  const unread = notifications.filter((n) => !n.read).length;
+
+  const fetchNotifications = useCallback(async () => {
+    if (!session?.token) return;
+    try {
+      const res = await fetch(`${API_BASE_URL}/api/notifications`, {
+        headers: { Authorization: `Bearer ${session.token}` },
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setNotifications(data.notifications || []);
+      }
+    } catch {
+      // silently fail — bell is non-critical
+    }
+  }, [session]);
+
+  useEffect(() => {
+    fetchNotifications();
+    // Poll every 30 s for new notifications
+    const interval = setInterval(fetchNotifications, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchNotifications]);
+
+  async function markAllRead() {
+    if (!session?.token) return;
+    try {
+      await fetch(`${API_BASE_URL}/api/notifications/read-all`, {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${session.token}` },
+        credentials: "include",
+      });
+      setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    } catch { /* ignore */ }
+  }
+
+  async function markOneRead(id) {
+    try {
+      await fetch(`${API_BASE_URL}/api/notifications/${id}/read`, {
+        method: "PATCH",
+        headers: { Authorization: `Bearer ${session?.token || ""}` },
+        credentials: "include",
+      });
+      setNotifications((prev) =>
+        prev.map((n) => (n._id === id ? { ...n, read: true } : n))
+      );
+    } catch { /* ignore */ }
+  }
+
+  if (!session?.user) return null;
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => {
+          setOpen((v) => !v);
+          if (!open && unread > 0) markAllRead();
+        }}
+        className="relative flex items-center justify-center rounded-full p-2 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        aria-label="Notifications"
+      >
+        <Bell className="h-5 w-5" />
+        {unread > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white">
+            {unread > 9 ? "9+" : unread}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          {/* backdrop */}
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+          />
+          {/* dropdown */}
+          <div className="absolute right-0 top-full z-50 mt-2 w-80 rounded-xl border border-border bg-background shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-4 py-3">
+              <span className="text-sm font-semibold">Notifications</span>
+              {notifications.some((n) => !n.read) && (
+                <button
+                  onClick={markAllRead}
+                  className="text-xs text-primary hover:underline"
+                >
+                  Mark all read
+                </button>
+              )}
+            </div>
+
+            <ul className="max-h-80 overflow-y-auto">
+              {notifications.length === 0 ? (
+                <li className="px-4 py-6 text-center text-sm text-muted-foreground">
+                  No notifications yet
+                </li>
+              ) : (
+                notifications.map((n) => (
+                  <li
+                    key={n._id}
+                    onClick={() => markOneRead(n._id)}
+                    className={`cursor-pointer border-b border-border/50 px-4 py-3 text-sm transition-colors hover:bg-muted/50 ${
+                      n.read ? "opacity-60" : "font-medium"
+                    }`}
+                  >
+                    <p className="leading-snug">{n.message}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {new Date(n.createdAt).toLocaleString()}
+                    </p>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/services/strategies/AvailabilityOnlyStrategy.js
+++ b/apps/web/src/services/strategies/AvailabilityOnlyStrategy.js
@@ -1,17 +1,49 @@
+/**
+ * AvailabilityOnlyStrategy
+ * Groups students to maximise shared availability slots.
+ * Students with more availability slots are "anchors" placed first;
+ * remaining students are matched to the anchor with the most overlap.
+ */
 class AvailabilityOnlyStrategy {
   generate(students, teamSize) {
-    const sorted = [...students].sort((a, b) => {
-      return b.availability.length - a.availability.length;
-    });
+    if (students.length === 0) return [];
 
-    return this.group(sorted, teamSize);
-  }
+    // Sort by slot count descending so anchors come first
+    const pool = [...students].sort(
+      (a, b) => b.availability.length - a.availability.length
+    );
 
-  group(students, teamSize) {
     const teams = [];
+    const assigned = new Set();
 
-    for (let i = 0; i < students.length; i += teamSize) {
-      teams.push(students.slice(i, i + teamSize));
+    for (let i = 0; i < pool.length; i++) {
+      if (assigned.has(i)) continue;
+
+      const team = [pool[i]];
+      assigned.add(i);
+
+      // Pick remaining teammates by overlap with current team
+      while (team.length < teamSize) {
+        let bestIdx = -1;
+        let bestOverlap = -1;
+
+        const teamSlots = new Set(team.flatMap((s) => s.availability));
+
+        for (let j = 0; j < pool.length; j++) {
+          if (assigned.has(j)) continue;
+          const overlap = pool[j].availability.filter((s) => teamSlots.has(s)).length;
+          if (overlap > bestOverlap) {
+            bestOverlap = overlap;
+            bestIdx = j;
+          }
+        }
+
+        if (bestIdx === -1) break;
+        team.push(pool[bestIdx]);
+        assigned.add(bestIdx);
+      }
+
+      teams.push(team);
     }
 
     return teams;

--- a/apps/web/src/services/strategies/SkillBalancedStrategy.js
+++ b/apps/web/src/services/strategies/SkillBalancedStrategy.js
@@ -1,17 +1,45 @@
+/**
+ * SkillBalancedStrategy
+ * Maximises unique skill coverage per team.
+ * Anchors on high-skill students, then adds members whose skills most
+ * complement the team's existing skill set.
+ */
 class SkillBalancedStrategy {
   generate(students, teamSize) {
-    const sorted = [...students].sort((a, b) => {
-      return b.skills.length - a.skills.length;
-    });
+    if (students.length === 0) return [];
 
-    return this.group(sorted, teamSize);
-  }
+    const pool = [...students].sort((a, b) => b.skills.length - a.skills.length);
 
-  group(students, teamSize) {
     const teams = [];
+    const assigned = new Set();
 
-    for (let i = 0; i < students.length; i += teamSize) {
-      teams.push(students.slice(i, i + teamSize));
+    for (let i = 0; i < pool.length; i++) {
+      if (assigned.has(i)) continue;
+
+      const team = [pool[i]];
+      assigned.add(i);
+
+      while (team.length < teamSize) {
+        let bestIdx = -1;
+        let bestNewSkills = -1;
+
+        const teamSkills = new Set(team.flatMap((s) => s.skills));
+
+        for (let j = 0; j < pool.length; j++) {
+          if (assigned.has(j)) continue;
+          const newSkills = pool[j].skills.filter((sk) => !teamSkills.has(sk)).length;
+          if (newSkills > bestNewSkills) {
+            bestNewSkills = newSkills;
+            bestIdx = j;
+          }
+        }
+
+        if (bestIdx === -1) break;
+        team.push(pool[bestIdx]);
+        assigned.add(bestIdx);
+      }
+
+      teams.push(team);
     }
 
     return teams;

--- a/apps/web/src/services/strategies/WeightedHybridStrategy.js
+++ b/apps/web/src/services/strategies/WeightedHybridStrategy.js
@@ -1,30 +1,64 @@
+/**
+ * WeightedHybridStrategy
+ * Balances availability overlap (weight 2) and skill diversity (weight 1).
+ * Anchors on the highest-scoring student, then greedily adds members by
+ * combined overlap + skill diversity score.
+ */
 class WeightedHybridStrategy {
   generate(students, teamSize) {
-    const sorted = [...students].sort((a, b) => {
-      return this.score(b) - this.score(a);
-    });
+    if (students.length === 0) return [];
 
-    return this.group(sorted, teamSize);
+    const pool = [...students].sort((a, b) => this.score(b) - this.score(a));
+
+    const teams = [];
+    const assigned = new Set();
+
+    for (let i = 0; i < pool.length; i++) {
+      if (assigned.has(i)) continue;
+
+      const team = [pool[i]];
+      assigned.add(i);
+
+      while (team.length < teamSize) {
+        let bestIdx = -1;
+        let bestScore = -Infinity;
+
+        const teamSlots = new Set(team.flatMap((s) => s.availability));
+        const teamSkills = new Set(team.flatMap((s) => s.skills));
+
+        for (let j = 0; j < pool.length; j++) {
+          if (assigned.has(j)) continue;
+          const candidate = pool[j];
+
+          const availOverlap =
+            candidate.availability.filter((s) => teamSlots.has(s)).length * 2;
+          const newSkills = candidate.skills.filter((sk) => !teamSkills.has(sk)).length;
+          const combined = availOverlap + newSkills;
+
+          if (combined > bestScore) {
+            bestScore = combined;
+            bestIdx = j;
+          }
+        }
+
+        if (bestIdx === -1) break;
+        team.push(pool[bestIdx]);
+        assigned.add(bestIdx);
+      }
+
+      teams.push(team);
+    }
+
+    return teams;
   }
 
   score(student) {
     const availabilityWeight = 2;
     const skillWeight = 1;
-
     return (
       student.availability.length * availabilityWeight +
       student.skills.length * skillWeight
     );
-  }
-
-  group(students, teamSize) {
-    const teams = [];
-
-    for (let i = 0; i < students.length; i += teamSize) {
-      teams.push(students.slice(i, i + teamSize));
-    }
-
-    return teams;
   }
 }
 


### PR DESCRIPTION
Reads availabilityGrid from the server response (the structured { "Monday": ["09:00-10:00"] } map) instead of just parsing raw answers. 

Frontend:
Rewrote Availability page to link to the correct workspace from the URL param, Full Day HH:MM-HH:MM slot columns grouped under day headers, Coverage counter per slot (3/5) color-coded green/yellow, Refresh button to pull live data, and Skills shown as chips on each row.

Added notification bell with icon and mark read and dismiss, polls notifications every 30s.

All 3 strategies rewritten with greedy overlap-aware grouping instead of a simple sort+slice each strategy now anchors on the best candidate and iteratively picks the next member who maximizes the relevant score (overlap for availability, new skills for skill-balanced, combined for weighted hybrid).

Backend:
Cleaned up to import from dedicated route files instead of inline routes in index. Updated notifications API and moved over survey API responses to responses.js